### PR TITLE
QKD functionality in kritis3m_tls_linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,6 @@ option(KRITIS3M_TLS_SELF_CONTAINED "Build a self-contained executable" OFF)
 # Use an externally installed ASL library. If disabled, ASL will be built.
 option(KRITIS3M_TLS_EXTERNAL_ASL "Use external ASL library" OFF)
 
-# Use an externally installed QUEST library. If disabled, QUEST will be built.
-option(KRITIS3M_TLS_EXTERNAL_QUEST "Use external ASL library" OFF)
-
-
 # Set the C standard to C17
 set(C_STANDARD 17)
 
@@ -122,35 +118,11 @@ else(KRITIS3M_TLS_EXTERNAL_ASL)
         endif()
 endif(KRITIS3M_TLS_EXTERNAL_ASL)
 
+# Link kritis3m_asl against the http(s) library
+target_link_libraries(kritis3m-http-libs PUBLIC kritis3m_asl)
 
-# Add the KRITIS3M-QUEST dependency
-if(KRITIS3M_TLS_EXTERNAL_QUEST)
-        # Search for system-wide installed libraries in both lib and lib64 paths
-        set(FIND_LIBRARY_USE_LIB32_PATHS TRUE)
-        set(FIND_LIBRARY_USE_LIB64_PATHS TRUE)
-
-        # Search for system-wide installed KRITIS3M_ASL
-        find_package(kritis3m-quest REQUIRED)
-
-else(KRITIS3M_TLS_EXTERNAL_QUEST)
-        # Add KRITIS3M_ASL as a dependency and build it
-        FetchContent_Declare(kritis3m-quest
-                GIT_REPOSITORY          git@github.com:Laboratory-for-Safe-and-Secure-Systems/kritis3m_quest.git
-                GIT_TAG                 origin/main
-                GIT_PROGRESS            TRUE
-        )
-
-        set(BUILD_SHARED_LIBS ON)
-        set(VERBOSE_PRINT OFF)
-
-        FetchContent_GetProperties(kritis3m-quest)
-        if(NOT kritis3m-quest_POPULATED)
-                FetchContent_Populate(kritis3m-quest)
-                add_subdirectory(${kritis3m-quest_SOURCE_DIR} ${kritis3m-quest_BINARY_DIR})
-        endif()
-endif(KRITIS3M_TLS_EXTERNAL_QUEST)
-
-
+# Link kritis3m-http-libs against the kritis3m-quest library
+target_link_libraries(kritis3m-quest PUBLIC kritis3m-http-libs)
 
 # Link the KRITIS3M_APPLICATIONS targets
 target_link_libraries(kritis3m_tls PUBLIC kritis3m_applications_common)
@@ -163,9 +135,9 @@ target_link_libraries(kritis3m_tls PUBLIC kritis3m_service)
 # Link KRITIS3M_ASL to the required KRITIS3M_APPLICATIONS targets
 target_link_libraries(kritis3m_applications_proxy PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_applications_network_tester PUBLIC kritis3m_asl)
+target_link_libraries(kritis3m_applications_common PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_applications_echo_server PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_service PUBLIC kritis3m_asl)
-target_link_libraries(kritis3m_http_libs PUBLIC kritis3m_asl)
 
 target_link_libraries(kritis3m_applications_proxy PUBLIC kritis3m_service)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ option(KRITIS3M_TLS_SELF_CONTAINED "Build a self-contained executable" OFF)
 # Use an externally installed ASL library. If disabled, ASL will be built.
 option(KRITIS3M_TLS_EXTERNAL_ASL "Use external ASL library" OFF)
 
+# Use an externally installed QUEST library. If disabled, QUEST will be built.
+option(KRITIS3M_TLS_EXTERNAL_QUEST "Use external ASL library" OFF)
+
 
 # Set the C standard to C17
 set(C_STANDARD 17)
@@ -120,6 +123,35 @@ else(KRITIS3M_TLS_EXTERNAL_ASL)
 endif(KRITIS3M_TLS_EXTERNAL_ASL)
 
 
+# Add the KRITIS3M-QUEST dependency
+if(KRITIS3M_TLS_EXTERNAL_QUEST)
+        # Search for system-wide installed libraries in both lib and lib64 paths
+        set(FIND_LIBRARY_USE_LIB32_PATHS TRUE)
+        set(FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+
+        # Search for system-wide installed KRITIS3M_ASL
+        find_package(kritis3m-quest REQUIRED)
+
+else(KRITIS3M_TLS_EXTERNAL_QUEST)
+        # Add KRITIS3M_ASL as a dependency and build it
+        FetchContent_Declare(kritis3m-quest
+                GIT_REPOSITORY          git@github.com:Laboratory-for-Safe-and-Secure-Systems/kritis3m_quest.git
+                GIT_TAG                 origin/main
+                GIT_PROGRESS            TRUE
+        )
+
+        set(BUILD_SHARED_LIBS ON)
+        set(VERBOSE_PRINT ON)
+
+        FetchContent_GetProperties(kritis3m-quest)
+        if(NOT kritis3m-quest_POPULATED)
+                FetchContent_Populate(kritis3m-quest)
+                add_subdirectory(${kritis3m-quest_SOURCE_DIR} ${kritis3m-quest_BINARY_DIR})
+        endif()
+endif(KRITIS3M_TLS_EXTERNAL_QUEST)
+
+
+
 # Link the KRITIS3M_APPLICATIONS targets
 target_link_libraries(kritis3m_tls PUBLIC kritis3m_applications_common)
 target_link_libraries(kritis3m_tls PUBLIC kritis3m_applications_echo_server)
@@ -140,6 +172,8 @@ target_link_libraries(kritis3m_applications_proxy PUBLIC kritis3m_service)
 # Link KRITIS3M_ASL to the main target
 target_link_libraries(kritis3m_tls PUBLIC kritis3m_asl)
 
+# Link KRITIS3M_QUEST to the main target
+target_link_libraries(kritis3m_tls PUBLIC kritis3m-quest)
 
 # Statically link the pthread library on Windows
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,10 +119,7 @@ else(KRITIS3M_TLS_EXTERNAL_ASL)
 endif(KRITIS3M_TLS_EXTERNAL_ASL)
 
 # Link kritis3m_asl against the http(s) library
-target_link_libraries(kritis3m-http-libs PUBLIC kritis3m_asl)
 
-# Link kritis3m-http-libs against the kritis3m-quest library
-target_link_libraries(kritis3m-quest PUBLIC kritis3m-http-libs)
 
 # Link the KRITIS3M_APPLICATIONS targets
 target_link_libraries(kritis3m_tls PUBLIC kritis3m_applications_common)
@@ -133,9 +130,9 @@ target_link_libraries(kritis3m_tls PUBLIC kritis3m_applications_network_tester)
 target_link_libraries(kritis3m_tls PUBLIC kritis3m_service)
 
 # Link KRITIS3M_ASL to the required KRITIS3M_APPLICATIONS targets
+target_link_libraries(kritis3m-http-libs PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_applications_proxy PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_applications_network_tester PUBLIC kritis3m_asl)
-target_link_libraries(kritis3m_applications_common PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_applications_echo_server PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_service PUBLIC kritis3m_asl)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ else(KRITIS3M_TLS_EXTERNAL_QUEST)
         )
 
         set(BUILD_SHARED_LIBS ON)
-        set(VERBOSE_PRINT ON)
+        set(VERBOSE_PRINT OFF)
 
         FetchContent_GetProperties(kritis3m-quest)
         if(NOT kritis3m-quest_POPULATED)

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,7 @@ struct qkd_key_info* kritis3m_allocate_key_info()
         struct qkd_key_info* key_info = malloc(sizeof(struct qkd_key_info));
         if (key_info == NULL)
         {
-                printf("[ QUEST ][ ERROR ] failed to allocate key_info struct in the\n");
+                LOG_ERROR("failed to allocate key_info struct.\n");
                 return NULL;
         }
 
@@ -96,7 +96,7 @@ enum kritis3m_status_info kritis3m_get_qkd_key(struct qkd_key_info* key_info, co
         {
                 if (strcmp(quest_config->response->key_info->key_ID, identity) != 0)
                 {
-                        printf("[ QUEST ][ ERROR ] identities do not match!\n");
+                        LOG_ERROR("identities do not match!\n");
                         status = E_NOT_OK;
                         goto LIB_ERR;
                 }

--- a/src/main.c
+++ b/src/main.c
@@ -14,11 +14,11 @@
 
 #include "echo_server.h"
 #include "http_service.h"
-#include "kritis3m-quest/quest.h"
 #include "kritis3m_scale_service.h"
 #include "network_tester.h"
 #include "tcp_client_stdin_bridge.h"
 #include "tls_proxy.h"
+#include "quest.h"
 
 #include "cli_parsing.h"
 

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 
 #include "echo_server.h"
 #include "http_service.h"
+#include "kritis3m-quest/quest.h"
 #include "kritis3m_scale_service.h"
 #include "network_tester.h"
 #include "tcp_client_stdin_bridge.h"
@@ -39,29 +40,119 @@ static void signal_handler(int signum)
         running = false;
 }
 
+/// @brief  allocates the qkd_key_info struct in the PSK Server Config (PSK_SRV_CONF).
+/// @return returns pointer to the qkd_key_info object if allocation was successfull, 
+///         otherwise returns NULL.
+struct qkd_key_info* kritis3m_allocate_key_info()
+{
+        struct qkd_key_info* key_info = malloc(sizeof(struct qkd_key_info));
+        if (key_info == NULL)
+        {
+                printf("[ QUEST ][ ERROR ] failed to allocate key_info struct in the\n");
+                return NULL;
+        }
+
+        return key_info;
+}
+
+/// @brief requests a new QKD key from the QKD line ether without or without a specific key_ID 
+///        parameter and copies the key and the identity to the key_info parameter.
+/// @param key_info struct object, which contains the reserved buffer for key and key_ID as 
+///        well as the associated sizes.
+/// @param identity (OPTIONAL) string of the key_ID sent by the client to the server to request 
+///        the corresponding QKD key. In case the tls client is calling this function, identity is 
+///        set to NULL.   
+/// @return returns the E_OK or a specific status return in case of an error.
+enum kritis3m_status_info kritis3m_get_qkd_key(struct qkd_key_info* key_info, const char* identity)
+{
+        enum kritis3m_status_info status;
+        struct quest_configuration* quest_config;
+
+        quest_config = quest_default_config();
+
+        /* if identity is NULL, we are on the client side requesting a new key without an ID */
+        if(identity == NULL)
+        {
+                /* modify the request type to key request WITHOUT an ID */
+                quest_config->request_type = HTTP_KEY_NO_ID;
+        }
+        else /* if an identity is passed as a parameter, we request a key with a specific ID */
+        {
+                quest_config->request_type = HTTP_KEY_WITH_ID;
+                quest_config->connection_info.hostname = "im-lfd-qkd-alice.othr.de";
+                memcpy(quest_config->key_ID, identity, strlen(identity));     
+        }
+
+        status = quest_init(quest_config);
+        if (status != E_OK)
+                goto LIB_ERR;
+
+        status = quest_send_request(quest_config);
+        if (status != E_OK)
+                goto LIB_ERR;
+
+        /* if identity is NULL, we can copy the key_ID and key to the key_info object */
+        if(identity != NULL)
+        {
+                if (strcmp(quest_config->response->key_info->key_ID, identity) != 0)
+                {
+                        printf("[ QUEST ][ ERROR ] identities do not match!\n");
+                        status = E_NOT_OK;
+                        goto LIB_ERR;
+                }
+        }
+
+        key_info->key_len = quest_config->response->key_info->key_len;
+        key_info->key_ID_len = quest_config->response->key_info->key_ID_len;
+
+        /* copy key from the http_response oject */
+        memcpy(key_info->key, quest_config->response->key_info->key, (key_info->key_len + 1));
+
+        /* copy key ID from the http_response object */
+        memcpy(key_info->key_ID, quest_config->response->key_info->key_ID, (key_info->key_ID_len + 1));
+
+LIB_ERR:
+        quest_deinit(quest_config);
+        return status;
+}
+
 unsigned int asl_psk_client_callback(char* key, char* identity, void* ctx)
 {
-        /* This is a dummy PSK client callback that always returns the same PSK key and identity */
-        const char* psk_key = (char const*) ctx;
-        const char* psk_identity = "builtin_identity";
+        (void) ctx;
+        enum kritis3m_status_info status;
+        struct qkd_key_info* key_info;
 
-        strcpy(key, psk_key);
-        strcpy(identity, psk_identity);
+        key_info = kritis3m_allocate_key_info();
+        if(key_info == NULL) return 0;
 
-        return strlen(psk_key);
+        status = kritis3m_get_qkd_key(key_info, NULL);
+        if(status == E_OK)
+        {
+                memcpy(key, key_info->key, (key_info->key_len + 1));
+                memcpy(identity, key_info->key_ID, (key_info->key_ID_len + 1));
+        }
+        
+        free(key_info);        
+        return strlen(key);
 }
 
 unsigned int asl_psk_server_callback(char* key, const char* identity, void* ctx)
 {
-        (void) identity;
+        (void) ctx;
+        enum kritis3m_status_info status;
+        struct qkd_key_info* key_info;
 
-        /* This is a dummy PSK server callback that always returns the same PSK key for all
-        identities */
-        const char* psk_key = (char const*) ctx;
+        key_info = kritis3m_allocate_key_info();
+        if(key_info == NULL) return 0;
 
-        strcpy(key, psk_key);
-
-        return strlen(psk_key);
+        status = kritis3m_get_qkd_key(key_info, identity);
+        if(status == E_OK)
+        {
+                memcpy(key, key_info->key, (key_info->key_len + 1));
+        }
+        
+        free(key_info);
+        return strlen(key);
 }
 
 int main(int argc, char** argv)

--- a/src/main.c
+++ b/src/main.c
@@ -41,7 +41,7 @@ static void signal_handler(int signum)
 }
 
 /// @brief  allocates the qkd_key_info struct in the PSK Server Config (PSK_SRV_CONF).
-/// @return returns pointer to the qkd_key_info object if allocation was successfull, 
+/// @return returns pointer to the qkd_key_info object if allocation was successfull,
 ///         otherwise returns NULL.
 struct qkd_key_info* kritis3m_allocate_key_info()
 {
@@ -55,13 +55,13 @@ struct qkd_key_info* kritis3m_allocate_key_info()
         return key_info;
 }
 
-/// @brief requests a new QKD key from the QKD line ether without or without a specific key_ID 
+/// @brief requests a new QKD key from the QKD line ether without or without a specific key_ID
 ///        parameter and copies the key and the identity to the key_info parameter.
-/// @param key_info struct object, which contains the reserved buffer for key and key_ID as 
+/// @param key_info struct object, which contains the reserved buffer for key and key_ID as
 ///        well as the associated sizes.
-/// @param identity (OPTIONAL) string of the key_ID sent by the client to the server to request 
-///        the corresponding QKD key. In case the tls client is calling this function, identity is 
-///        set to NULL.   
+/// @param identity (OPTIONAL) string of the key_ID sent by the client to the server to request
+///        the corresponding QKD key. In case the tls client is calling this function, identity is
+///        set to NULL.
 /// @return returns the E_OK or a specific status return in case of an error.
 enum kritis3m_status_info kritis3m_get_qkd_key(struct qkd_key_info* key_info, const char* identity)
 {
@@ -71,7 +71,7 @@ enum kritis3m_status_info kritis3m_get_qkd_key(struct qkd_key_info* key_info, co
         quest_config = quest_default_config();
 
         /* if identity is NULL, we are on the client side requesting a new key without an ID */
-        if(identity == NULL)
+        if (identity == NULL)
         {
                 /* modify the request type to key request WITHOUT an ID */
                 quest_config->request_type = HTTP_KEY_NO_ID;
@@ -80,7 +80,7 @@ enum kritis3m_status_info kritis3m_get_qkd_key(struct qkd_key_info* key_info, co
         {
                 quest_config->request_type = HTTP_KEY_WITH_ID;
                 quest_config->connection_info.hostname = "im-lfd-qkd-alice.othr.de";
-                memcpy(quest_config->key_ID, identity, strlen(identity));     
+                memcpy(quest_config->key_ID, identity, strlen(identity));
         }
 
         status = quest_init(quest_config);
@@ -92,7 +92,7 @@ enum kritis3m_status_info kritis3m_get_qkd_key(struct qkd_key_info* key_info, co
                 goto LIB_ERR;
 
         /* if identity is NULL, we can copy the key_ID and key to the key_info object */
-        if(identity != NULL)
+        if (identity != NULL)
         {
                 if (strcmp(quest_config->response->key_info->key_ID, identity) != 0)
                 {
@@ -123,16 +123,17 @@ unsigned int asl_psk_client_callback(char* key, char* identity, void* ctx)
         struct qkd_key_info* key_info;
 
         key_info = kritis3m_allocate_key_info();
-        if(key_info == NULL) return 0;
+        if (key_info == NULL)
+                return 0;
 
         status = kritis3m_get_qkd_key(key_info, NULL);
-        if(status == E_OK)
+        if (status == E_OK)
         {
                 memcpy(key, key_info->key, (key_info->key_len + 1));
                 memcpy(identity, key_info->key_ID, (key_info->key_ID_len + 1));
         }
-        
-        free(key_info);        
+
+        free(key_info);
         return strlen(key);
 }
 
@@ -143,14 +144,15 @@ unsigned int asl_psk_server_callback(char* key, const char* identity, void* ctx)
         struct qkd_key_info* key_info;
 
         key_info = kritis3m_allocate_key_info();
-        if(key_info == NULL) return 0;
+        if (key_info == NULL)
+                return 0;
 
         status = kritis3m_get_qkd_key(key_info, identity);
-        if(status == E_OK)
+        if (status == E_OK)
         {
                 memcpy(key, key_info->key, (key_info->key_len + 1));
         }
-        
+
         free(key_info);
         return strlen(key);
 }


### PR DESCRIPTION
Pull request to integrate QKD functionality (quest_lib usage) into the main branch of the repository.
Changes to the kritis3m_tls_linux are listed as follows:

### Key Changes:
- implementation of usage of the quest library (from the kritis3m_applications repository) populating the quest configuration and sending the request in the asl_server_cb and asl_client_cb.
- Handling of http-response to derive QKD key and key-ID in the implementation.
- removed dummy implementation in asl_{server, client}_cb functions.

### Modifications:
- adjusted **cmake build process** in top-level _CMakeLists.txt_ to contain the quest_lib and link the **kritis3m_asl** library against the **http_lib** and subsequently link the **http_lib** against the **quest_lib**.
- at last **link** quest_lib against kritis3m_tls
- **removed** dummy implementation from asl PSK callbacks.

### Others:
- none