### PR TITLE
CLI Support for secured (and encrypted) key requests to the QKD line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ target_link_libraries(kritis3m_tls PUBLIC kritis3m_service)
 
 # Link KRITIS3M_ASL to the required KRITIS3M_APPLICATIONS targets
 target_link_libraries(kritis3m-http-libs PUBLIC kritis3m_asl)
+target_link_libraries(kritis3m-quest PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_applications_proxy PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_applications_network_tester PUBLIC kritis3m_asl)
 target_link_libraries(kritis3m_applications_echo_server PUBLIC kritis3m_asl)

--- a/includes/cli_parsing.h
+++ b/includes/cli_parsing.h
@@ -14,6 +14,8 @@
 
 #define EXTERNAL_PSK_IDENTIFIER "qkd"
 #define EXTERNAL_PSK_IDENTIFIER_LEN 3
+#define SECURE_EXTERNAL_PSK_IDENTIFIER "qkd:secure"
+#define SECURE_EXTERNAL_PSK_IDENTIFIER_LEN 10
 
 enum application_role
 {

--- a/includes/cli_parsing.h
+++ b/includes/cli_parsing.h
@@ -9,6 +9,7 @@
 #include "logging.h"
 #include "network_tester.h"
 #include "tls_proxy.h"
+#include "quest.h"
 
 #define LOCALHOST_IP "127.0.0.1"
 
@@ -45,6 +46,7 @@ int parse_cli_arguments(application_config* app_config,
                         proxy_config* proxy_config,
                         echo_server_config* echo_server_config,
                         network_tester_config* tester_config,
+                        quest_configuration* quest_config,
                         char** management_file_path,
                         size_t argc,
                         char** argv);
@@ -55,7 +57,8 @@ void arguments_cleanup(application_config* app_config,
                        proxy_config* proxy_config,
                        echo_server_config* echo_server_config,
                        char** management_file_path,
-                       network_tester_config* tester_config);
+                       network_tester_config* tester_config,
+                       quest_configuration* quest_config);
 
 /* Helper method to dynamically duplicate a string */
 char* duplicate_string(char const* source);

--- a/src/cli_parsing.c
+++ b/src/cli_parsing.c
@@ -618,6 +618,12 @@ static int check_qkd_config(asl_endpoint_configuration* qkd_config,
                         return -1;
                 }
 
+                if(tls_config->keylog_file != NULL)
+                {
+                        /* For debug reasons, we copy the keylog_file from the tls_config */
+                        qkd_config->keylog_file = duplicate_string(tls_config->keylog_file);
+                }
+
                 /* We pass the resulting asl_endpoint to the callback_ctx */
                 asl_endpoint* https_endpoint = asl_setup_client_endpoint(qkd_config);
                 tls_config->psk.callback_ctx = https_endpoint;

--- a/src/cli_parsing.c
+++ b/src/cli_parsing.c
@@ -618,12 +618,6 @@ static int check_qkd_config(asl_endpoint_configuration* qkd_config,
                         return -1;
                 }
 
-                if(tls_config->keylog_file != NULL)
-                {
-                        /* For debug reasons, we copy the keylog_file from the tls_config */
-                        qkd_config->keylog_file = duplicate_string(tls_config->keylog_file);
-                }
-
                 /* We pass the resulting asl_endpoint to the callback_ctx */
                 asl_endpoint* https_endpoint = asl_setup_client_endpoint(qkd_config);
                 tls_config->psk.callback_ctx = https_endpoint;
@@ -650,11 +644,6 @@ static int check_qkd_config(asl_endpoint_configuration* qkd_config,
         {
                 free((void*) qkd_config->device_certificate_chain.buffer);
                 qkd_config->device_certificate_chain.size = 0;
-        }
-        if (qkd_config->keylog_file != NULL)
-        {
-                free((void*) qkd_config->keylog_file);
-                qkd_config->keylog_file = NULL;
         }
 
         return 0;

--- a/src/cli_parsing.c
+++ b/src/cli_parsing.c
@@ -433,17 +433,17 @@ int parse_cli_arguments(application_config* app_config,
         if (qkd_certs.certificate_path != NULL)
         {
                 free((void*) qkd_certs.certificate_path);
-                certs.certificate_path = NULL;
+                qkd_certs.certificate_path = NULL;
         }
         if (qkd_certs.root_path != NULL)
         {
                 free((void*) qkd_certs.root_path);
-                certs.root_path = NULL;
+                qkd_certs.root_path = NULL;
         }
         if (qkd_certs.private_key_path != NULL)
         {
                 free((void*) qkd_certs.private_key_path);
-                certs.private_key_path = NULL;
+                qkd_certs.private_key_path = NULL;
         }
 
         qkd_config.device_certificate_chain.buffer = qkd_certs.chain_buffer;

--- a/src/cli_parsing.c
+++ b/src/cli_parsing.c
@@ -26,9 +26,9 @@ static const struct option cli_options[] = {
         {"pre_shared_key", required_argument, 0, 0x0A},
         {"psk_enable_certs", no_argument, 0, 0x19},
 
-        {"https_cert", required_argument, 0, 0x20},
-        {"https_key", required_argument, 0, 0x21},
-        {"https_root", required_argument, 0, 0x22},
+        {"qkd_cert", required_argument, 0, 0x20},
+        {"qkd_key", required_argument, 0, 0x21},
+        {"qkd_root", required_argument, 0, 0x22},
 
         {"pkcs11_module", required_argument, 0, 0x0C},
         {"pkcs11_pin", required_argument, 0, 0x0D},
@@ -618,6 +618,12 @@ static int check_qkd_config(asl_endpoint_configuration* qkd_config,
                         return -1;
                 }
 
+                if(tls_config->keylog_file != NULL)
+                {
+                        /* For debug reasons, we copy the keylog_file from the tls_config */
+                        qkd_config->keylog_file = duplicate_string(tls_config->keylog_file);
+                }
+
                 /* We pass the resulting asl_endpoint to the callback_ctx */
                 asl_endpoint* https_endpoint = asl_setup_client_endpoint(qkd_config);
                 tls_config->psk.callback_ctx = https_endpoint;
@@ -644,6 +650,11 @@ static int check_qkd_config(asl_endpoint_configuration* qkd_config,
         {
                 free((void*) qkd_config->device_certificate_chain.buffer);
                 qkd_config->device_certificate_chain.size = 0;
+        }
+        if (qkd_config->keylog_file != NULL)
+        {
+                free((void*) qkd_config->keylog_file);
+                qkd_config->keylog_file = NULL;
         }
 
         return 0;
@@ -837,9 +848,9 @@ static void print_help(char const* name)
         printf("  --pre_shared_key \"%s\"         Results in a HTTP request to the QKD key magament system and subsequent a QKD PSK.\r\n", EXTERNAL_PSK_IDENTIFIER);
         printf("  --pre_shared_key \"%s\"  Results in a (secured) HTPPS request to the QKD key management system and subsequent a QKD PSK.\r\n", SECURE_EXTERNAL_PSK_IDENTIFIER);
         printf("                                    In this mode, the https parameter must be set.\r\n");
-        printf("  --https_cert file_path         Path to the certificate file used for the HTTPS connection to the QKD line\r\n");
-        printf("  --https_root file_path         Path to the root certificate file used for the HTTPS connection to the QKD line\r\n");
-        printf("  --https_key file_path          Path to the private key file used for the HTTPS connection to the QKD line\r\n");
+        printf("  --qkd_cert file_path         Path to the certificate file used for the HTTPS connection to the QKD line\r\n");
+        printf("  --qkd_root file_path         Path to the root certificate file used for the HTTPS connection to the QKD line\r\n");
+        printf("  --qkd_key file_path          Path to the private key file used for the HTTPS connection to the QKD line\r\n");
 
         printf("\nPKCS#11:\r\n");
         printf("  When using a PKCS#11 token for key/cert storage, you have to supply the PKCS#11 labels using the arguments\n");

--- a/src/cli_parsing.c
+++ b/src/cli_parsing.c
@@ -631,25 +631,30 @@ static int check_qkd_config(asl_endpoint_configuration* qkd_config,
         } /* Otherwise we can clear the qkd_config (not required for unsecure qkd) */
         else
         {
-                /* In this case we do not need any additional fields. Clear all unused parameters */
-                if (qkd_config->root_certificate.buffer != NULL)
-                {
-                        free((void*) qkd_config->root_certificate.buffer);
-                        qkd_config->root_certificate.size = 0;
-                }
-                if (qkd_config->private_key.buffer != NULL)
-                {
-                        free((void*) qkd_config->private_key.buffer);
-                        qkd_config->private_key.size = 0;
-                }
-                if (qkd_config->device_certificate_chain.buffer != NULL)
-                {
-                        free((void*) qkd_config->device_certificate_chain.buffer);
-                        qkd_config->device_certificate_chain.size = 0;
-                }
-
-                /* We pass NULL to the callback_ctx */
+                /* In this case we do not need any additional fields and pass NULL to the callback_ctx */
                 tls_config->psk.callback_ctx = NULL;
+        }
+
+        /* As last step, we clean-up the qkd_config */
+        if (qkd_config->root_certificate.buffer != NULL)
+        {
+                free((void*) qkd_config->root_certificate.buffer);
+                qkd_config->root_certificate.size = 0;
+        }
+        if (qkd_config->private_key.buffer != NULL)
+        {
+                free((void*) qkd_config->private_key.buffer);
+                qkd_config->private_key.size = 0;
+        }
+        if (qkd_config->device_certificate_chain.buffer != NULL)
+        {
+                free((void*) qkd_config->device_certificate_chain.buffer);
+                qkd_config->device_certificate_chain.size = 0;
+        }
+        if (qkd_config->keylog_file != NULL)
+        {
+                free((void*) qkd_config->keylog_file);
+                qkd_config->keylog_file = NULL;
         }
 
         return 0;


### PR DESCRIPTION
Pull request to integrate changes adding CLI arguments to use HTTPS functionality on Linux. Changes to the **kritis3m_tls_linux** are listed as follows:

### Key Changes:
- added new **certificates** struct and **asl_endpoint_config** for the secured QKD connection. 
- added new function to check if the qkd_config is set up correctly, and derive the **asl_endpoint**, which is passed to the callback_function of the PSK via _tls_config->psk.callback_ctx_ reference.
- added new SECURE_EXTERNAL_PSK_IDENTIFIER to differentiate between secure and insecure request modes.

---

### Modifications:
- adjusted **help dialog** according to the new changes in the CLI arguments.
- adjusted _kritis3m_get_qkd_key()_ function in the **main.c** file to use the callback_ctx to establish a TLS session.
- removed previous passed callback_ctx argument in the _check_psk_config()_ function, as it is no longer needed.
- added linker-statement to link kritis3m_asl against the quest_lib in toplevel **CMakeLists.txt**

---

### Open Issues:
- Due to the QKD line maintenance, we currently hardcode the **connection_info.hostname** to **127.0.0.2**. This must be removed in the future.
- The current set of **built_in certificates** is used to establish the HTTPS connection to the **qkd_mock_server**. This works, because the server uses identical certificates. For the real QKD line, we probably need to add a new set of certificates.
- The changes in the callback_ctx require new handling for the **asl_endpoint** passed to the PSK_callback_function, as the asl_endpoint_config for secure QKD requests now contains an object of struct **asl_endpoint**. This must be considered in the  __free()__ call of the derived asl_endpoint! A possible solution might be a recursive call of the _asl_free_endpoint()__ function...