### PR TITLE
New CLI argument to use PSKs in secure connection to the QKD line 

### DIFF
--- a/scripts/kritis3m_tls-completion.bash
+++ b/scripts/kritis3m_tls-completion.bash
@@ -51,6 +51,8 @@
 #   --qkd_cert file_path           Path to the certificate file used for the HTTPS connection to the QKD server
 #   --qkd_root file_path           Path to the root certificate file used for the HTTPS connection to the QKD server
 #   --qkd_key file_path            Path to the private key file used for the HTTPS connection to the QKD server
+#   --qkd_psk id:key               Pre-shared key and identity to use for the HTTPS connectionto the QKD server.
+#                                     The key has to be Base64 encoded.  
 #
 # PKCS#11:
 #   When using a PKCS#11 token for key/cert storage, you have to supply the PKCS#11 labels using the arguments
@@ -96,7 +98,7 @@ _kritis3m_tls_completions() {
         roles="reverse_proxy forward_proxy echo_server echo_server_proxy tls_client network_tester network_tester_proxy management_client"
         opts_connection="--incoming --outgoing"
         opts_files="--cert --key --intermediate --root --additional_key --pkcs11_module --keylog_file --qkd_cert --qkd_root --qkd_key"
-        opts_security="--no_mutual_auth --ciphersuites --key_exchange_alg --pre_shared_key --psk_no_dhe --psk_no_cert_auth --pkcs11_pin --pkcs11_crypto_all"
+        opts_security="--no_mutual_auth --ciphersuites --key_exchange_alg --pre_shared_key --psk_no_dhe --psk_no_cert_auth --pkcs11_pin --pkcs11_crypto_all --qkd_psk"
         opts_tester="--test_num_handshakes --test_handshake_delay --test_num_messages --test_message_delay --test_message_size \
                         --test_output_path --test_no_tls --test_silent"
         opts_mgmt="--mgmt_path"
@@ -134,7 +136,7 @@ _kritis3m_tls_completions() {
                 COMPREPLY=($(compgen -W "${kex_algos}" -- ${cur}))
                 return 0
                 ;;
-        --no_mutual_auth | --ciphersuites | --pre_shared_key | --psk_no_dhe | --psk_no_cert_auth | --test_num_handshakes | --test_handshake_delay | \
+        --no_mutual_auth | --ciphersuites | --pre_shared_key | --psk_no_dhe | --psk_no_cert_auth | --qkd_psk | --test_num_handshakes | --test_handshake_delay | \
                 --test_num_messages | --test_message_delay | --test_message_size | --test_no_tls | --test_silent | --pkcs11_pin | pkcs11_crypto_all)
                 # No specific completion
                 COMPREPLY=()

--- a/src/cli_parsing.c
+++ b/src/cli_parsing.c
@@ -392,7 +392,7 @@ int parse_cli_arguments(application_config* app_config,
                         /* In the optarg, the concatination <id:key> is present. We strip
                         * the key from the identity below. */
                         qkd_config.psk.identity = duplicate_string(optarg);
-                        if (tls_config.psk.identity == NULL)
+                        if (qkd_config.psk.identity == NULL)
                         {
                                 LOG_ERROR("unable to allocate memory for PSK key");
                                 return -1;

--- a/src/cli_parsing.c
+++ b/src/cli_parsing.c
@@ -30,6 +30,7 @@ static const struct option cli_options[] = {
         {"qkd_cert", required_argument, 0, 0x20},
         {"qkd_key", required_argument, 0, 0x21},
         {"qkd_root", required_argument, 0, 0x22},
+        {"qkd_psk", required_argument, 0, 0x24},
 
         {"pkcs11_module", required_argument, 0, 0x0C},
         {"pkcs11_pin", required_argument, 0, 0x0D},
@@ -386,6 +387,17 @@ int parse_cli_arguments(application_config* app_config,
                 case 0x23: /* psk disable (EC)DHE */
                         tls_config.psk.enable_dhe_psk = false;
                         break;
+                case 0x24: /* qkd pre-shared key */
+                        qkd_config.psk.enable_psk = true;
+                        /* In the optarg, the concatination <id:key> is present. We strip
+                        * the key from the identity below. */
+                        qkd_config.psk.identity = duplicate_string(optarg);
+                        if (tls_config.psk.identity == NULL)
+                        {
+                                LOG_ERROR("unable to allocate memory for PSK key");
+                                return -1;
+                        }
+                        break;
                 case 'v': /* verbose */
                         app_config->log_level = LOG_LVL_INFO;
                         break;
@@ -633,6 +645,13 @@ static int check_qkd_config(quest_configuration* quest_config,
                 {
                         LOG_ERROR("QKD certificates are mandatory for secure QKD connection");
                         return -1;
+                }
+
+                /* In case the connetion to the qkd line shall be secured with a psk */
+                if(qkd_config->psk.enable_psk)
+                {
+                        if(check_pre_shared_key(qkd_config, app_config) != 0)
+                                return -1;
                 }
 
                 if (tls_config->keylog_file != NULL)
@@ -905,6 +924,8 @@ static void print_help(char const* name)
         printf("  --qkd_cert file_path           Path to the certificate file used for the HTTPS connection to the QKD server\r\n");
         printf("  --qkd_root file_path           Path to the root certificate file used for the HTTPS connection to the QKD server\r\n");
         printf("  --qkd_key file_path            Path to the private key file used for the HTTPS connection to the QKD server\r\n");
+        printf("  --qkd_psk id:key               Pre-shared key and identity to use for the HTTPS connection to the QKD server\r\n");
+        printf("                                    The key has to be Base64 encoded.\r\n");
 
         printf("\nPKCS#11:\r\n");
         printf("  When using a PKCS#11 token for key/cert storage, you have to supply the PKCS#11 labels using the arguments\n");


### PR DESCRIPTION
As part of the publication, it is necessary to use a **PSK** in the connection to the **QKD line**. The new changes contain a new CLI argument in the kritis3m_tls_linux, which allows this new parameter.

### Modifications
- new CLI argument `--qkd_psk` to use a pre-shared key in the connection to the QKD line. 
-  new print statement in the help dialog